### PR TITLE
Race-free Varnish.Close()

### DIFF
--- a/log.go
+++ b/log.go
@@ -60,7 +60,7 @@ func (v *Varnish) Log(query string, grouping uint32, logCallback LogCallback) er
 	if v.vslq == nil {
 		return errors.New(C.GoString(C.VSL_Error(v.vsl)))
 	}
-	for v.alive {
+	for v.alive() {
 		i := C.VSLQ_Dispatch(v.vslq,
 			(*C.VSLQ_dispatch_f)(unsafe.Pointer(C.dispatchCallback)),
 			handle)


### PR DESCRIPTION
Hello & thank you for `vago,

I am writing a small vago wrapper that emits request logs to Kafka, in that script I noticed that calling `Close()` from a different goroutine is racy, this patch tries to address that. The following warning can be triggered by running the `TestLogGoroutineClose()` in the current master branch.

```
$ go test -race
WARNING: DATA RACE
Read at 0x00c4201855d0 by goroutine 10:
  github.com/phenomenes/vago.(*Varnish).Close()
      /home/yatiohi/go/src/github.com/phenomenes/vago/vago.go:102 +0xa0
  github.com/phenomenes/vago.TestLogGoroutineClose()
      /home/yatiohi/go/src/github.com/phenomenes/vago/vago_test.go:58 +0x173
  testing.tRunner()
      /usr/lib/go-1.8/src/testing/testing.go:657 +0x107

Previous write at 0x00c4201855d0 by goroutine 11:
  [failed to restore the stack]

Goroutine 10 (running) created at:
  testing.(*T).Run()
      /usr/lib/go-1.8/src/testing/testing.go:697 +0x543
  testing.runTests.func1()
      /usr/lib/go-1.8/src/testing/testing.go:882 +0xaa
  testing.tRunner()
      /usr/lib/go-1.8/src/testing/testing.go:657 +0x107
  testing.runTests()
      /usr/lib/go-1.8/src/testing/testing.go:888 +0x4e0
  testing.(*M).Run()
      /usr/lib/go-1.8/src/testing/testing.go:822 +0x1c3
  main.main()
      github.com/phenomenes/vago/_test/_testmain.go:54 +0x20f

Goroutine 11 (running) created at:
  github.com/phenomenes/vago.TestLogGoroutineClose()
      /home/yatiohi/go/src/github.com/phenomenes/vago/vago_test.go:55 +0x158
  testing.tRunner()
      /usr/lib/go-1.8/src/testing/testing.go:657 +0x107
```