### PR TITLE
Return C.int instead of int32

### DIFF
--- a/log.go
+++ b/log.go
@@ -118,7 +118,7 @@ func dispatchCallback(vsl *C.struct_VSL_data, pt **C.struct_VSL_transaction, han
 		for {
 			i := C.VSL_Next((*t).c)
 			if i < 0 {
-				return i
+				return C.int(i)
 			}
 			if i == 0 {
 				break


### PR DESCRIPTION
Hi,

I tried to build varnishlogbeat and got the following error:

```go/src/github.com/phenomenes/varnishlogbeat/vendor/github.com/phenomenes/vago/log.go:121: cannot use i (type int32) as type C.int in return argument```

GoLang version: ```go version go1.9.4 linux/amd64```

Varnish version: ```varnishd (varnish-6.0.0 revision a068361dff0d25a0d85cf82a6e5fdaf315e06a7d)```

I changed the return value from ```int32``` to ```C.int.```

Best,
Dennis